### PR TITLE
delete successive labels merging; add data extraction with setted length

### DIFF
--- a/synchronize.py
+++ b/synchronize.py
@@ -14,9 +14,9 @@ map_long_sample_freq = {
 } #unit: second
 
 subject = 1
-walks = [3]
-fps_for_frame = 30
-video_sync_modality_frame = 'PupilFrame'
+walks = [1]
+fps_for_frame = 60
+video_sync_modality_frame = 'GoProFrame'
 time_window = 2  # Unit: second
 
 def extract_video_noaudio_subset(video_path, start_frame, end_frame, output_path, time_window = None, fps=None):


### PR DESCRIPTION
In downstream task, we need data with identical length for training. To simplify the data process of downstream task, we directly extract data with required length here.

The padding method is as follow. If an event (label) is shorter than required length, we put it in the middle and expand the start time and end time to exactly the required length, and extract the data in this new period. If an event is longer than required length, we do normal processes. In the training of downstream task, we will cut them into small pieces.

To make sure short events will occur in the middle of our extracted data, we abort successive labels merging.